### PR TITLE
Fix app startup crash issue #139

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/datasette_app_support/__init__.py
+++ b/datasette_app_support/__init__.py
@@ -41,7 +41,7 @@ def startup(datasette):
                     and installed_version
                     and (
                         version.parse(installed_version)
-                        < version.parse(plugin["tag_name"])
+                        < version.parse(plugin.get("tag_name", ""))
                     )
                 )
                 else None

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         ],
     },
     entry_points={"datasette": ["app_support = datasette_app_support"]},
-    install_requires=["datasette>=0.59a2", "sqlite-utils", "packaging"],
+    install_requires=["datasette>=0.59", "sqlite-utils", "packaging"],
     extras_require={"test": ["pytest", "pytest-asyncio", "black", "pytest-httpx"]},
     tests_require=["datasette-app-support[test]"],
     python_requires=">=3.6",

--- a/tests/test_auth_app_user.py
+++ b/tests/test_auth_app_user.py
@@ -10,7 +10,6 @@ async def test_auth_app_user():
         "/-/auth-app-user",
         json={"redirect": "/-/metadata"},
         headers={"Authorization": "Bearer fake-token"},
-        allow_redirects=False,
     )
     assert response.status_code == 302
     assert response.headers["location"] == "/-/metadata"

--- a/tests/test_dump_restore_temporary.py
+++ b/tests/test_dump_restore_temporary.py
@@ -22,7 +22,6 @@ async def test_dump_temporary_to_file(tmpdir):
         "/-/dump-temporary-to-file",
         json={"path": backup_path},
         headers={"Authorization": "Bearer fake-token"},
-        allow_redirects=False,
     )
     assert response.status_code == 200
     assert response.json() == {"ok": True, "path": backup_path}
@@ -50,7 +49,6 @@ async def test_restore_temporary_from_file(tmpdir):
         "/-/restore-temporary-from-file",
         json={"path": backup_path},
         headers={"Authorization": "Bearer fake-token"},
-        allow_redirects=False,
     )
     assert response.status_code == 200
     assert response.json() == {

--- a/tests/test_open_csv_file.py
+++ b/tests/test_open_csv_file.py
@@ -65,7 +65,7 @@ async def test_import_csv_files(tmpdir):
 )
 async def test_import_csv_url(httpx_mock, table_name, expected):
     httpx_mock.add_response(
-        url="http://example.com/test.csv", data="id,name\n1,Banyan\n2,Crystal"
+        url="http://example.com/test.csv", text="id,name\n1,Banyan\n2,Crystal"
     )
     datasette = Datasette([], memory=True)
     await datasette.invoke_startup()

--- a/tests/test_plugin_directory.py
+++ b/tests/test_plugin_directory.py
@@ -45,7 +45,7 @@ async def test_plugin_directory():
 async def test_plugin_directory_no_connection(httpx_mock):
     httpx_mock.reset(False)
 
-    def raise_timeout(request, extensions: dict):
+    def raise_timeout(request):
         raise httpx.NetworkError("No internet connection", request=request)
 
     httpx_mock.add_callback(raise_timeout)


### PR DESCRIPTION
This fixes https://github.com/simonw/datasette-app/issues/139 on my install.

Notes on how to reproduce the crash and fix.

- Started datasette app offline
- Enabled Debug Menu via About menu
- From Debug Menu chose "Restart server"
- Captured python stack trace below
- Made a super quick fix to default `tag_name` to an empty string if it's not defined in plugin dict on startup


```
9:15:57 PM: Shutting down
9:15:57 PM: Waiting for application shutdown.
9:15:57 PM: Application shutdown complete.
9:15:57 PM: Finished server process [60451]
9:15:57 PM: Traceback (most recent call last):
9:15:57 PM:   File "/Users/m.collins/.datasette-app/venv/bin/datasette", line 8, in <module>
9:15:57 PM:     sys.exit(cli())
9:15:57 PM:   File "/Users/m.collins/.datasette-app/venv/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
9:15:57 PM:     return self.main(*args, **kwargs)
9:15:57 PM:   File "/Users/m.collins/.datasette-app/venv/lib/python3.9/site-packages/click/core.py", line 1055, in main
9:15:57 PM:     rv = self.invoke(ctx)
9:15:57 PM:   File "/Users/m.collins/.datasette-app/venv/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
9:15:57 PM:     return _process_result(sub_ctx.command.invoke(sub_ctx))
9:15:57 PM:   File "/Users/m.collins/.datasette-app/venv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
9:15:57 PM:     return ctx.invoke(self.callback, **ctx.params)
9:15:57 PM:   File "/Users/m.collins/.datasette-app/venv/lib/python3.9/site-packages/click/core.py", line 760, in invoke
9:15:57 PM:     return __callback(*args, **kwargs)
9:15:57 PM:   File "/Users/m.collins/.datasette-app/venv/lib/python3.9/site-packages/datasette/cli.py", line 582, in serve
9:15:57 PM:     asyncio.get_event_loop().run_until_complete(ds.invoke_startup())
9:15:57 PM:   File "/Applications/Datasette.app/Contents/Resources/python/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
9:15:57 PM:     return future.result()
9:15:57 PM:   File "/Users/m.collins/.datasette-app/venv/lib/python3.9/site-packages/datasette/app.py", line 387, in invoke_startup
9:15:57 PM:     await await_me_maybe(hook)
9:15:57 PM:   File "/Users/m.collins/.datasette-app/venv/lib/python3.9/site-packages/datasette/utils/__init__.py", line 111, in await_me_maybe
9:15:57 PM:     value = await value
9:15:57 PM:   File "/Users/m.collins/.datasette-app/venv/lib/python3.9/site-packages/datasette_app_support/__init__.py", line 44, in inner
9:15:57 PM:     < version.parse(plugin["tag_name"])
9:15:57 PM: KeyError: 'tag_name'
```